### PR TITLE
Fix/main

### DIFF
--- a/src/SignUp/Signup.jsx
+++ b/src/SignUp/Signup.jsx
@@ -90,6 +90,16 @@ const Signup = () => {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
+
+    // 나이 필드의 경우 음수 값 방지 및 경고
+    if (name === 'age') {
+      const numValue = Number(value);
+      if (value && (numValue < 0 || numValue > 150)) {
+        alert('진짜 당신의 나이가 맞나요??');
+        return; // 0 미만이거나 150 초과인 경우 업데이트하지 않음
+      }
+    }
+
     setFormData((prev) => ({ ...prev, [name]: value }));
 
     if (name === 'id') {
@@ -271,6 +281,8 @@ const Signup = () => {
                 placeholder="나이"
                 value={formData.age}
                 onChange={handleChange}
+                min="1"
+                max="150"
               />
             </div>
             <div className="select-wrap">

--- a/src/SignUp/Signup.jsx
+++ b/src/SignUp/Signup.jsx
@@ -74,6 +74,7 @@ const Signup = () => {
   const [isIdAvailable, setIsIdAvailable] = useState(false);
   const [isIdChecked, setIsIdChecked] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [ageErrorMessage, setAgeErrorMessage] = useState('');
 
   useEffect(() => {
     const script = document.createElement('script');
@@ -95,8 +96,10 @@ const Signup = () => {
     if (name === 'age') {
       const numValue = Number(value);
       if (value && (numValue < 0 || numValue > 150)) {
-        alert('진짜 당신의 나이가 맞나요??');
+        setAgeErrorMessage('진짜 당신의 나이가 맞나요??');
         return; // 0 미만이거나 150 초과인 경우 업데이트하지 않음
+      } else {
+        setAgeErrorMessage('');
       }
     }
 
@@ -273,7 +276,7 @@ const Signup = () => {
                 onChange={handleChange}
               />
             </div>
-            <div className="input-field">
+            <div className="input-field" style={{ marginBottom: 0 }}>
               <input
                 className="s-input"
                 type="number"
@@ -285,6 +288,9 @@ const Signup = () => {
                 max="150"
               />
             </div>
+            <p className="msg-error">
+              {ageErrorMessage}
+            </p>
             <div className="select-wrap">
               <div className="select-box" onClick={toggleGenderOptions}>
                 {formData.gender || "성별"}

--- a/src/chat/Chat.jsx
+++ b/src/chat/Chat.jsx
@@ -38,8 +38,7 @@ export default function Chat() {
     const token = getAccessToken();
 
     if (!token) {
-      alert('로그인이 필요합니다. 로그인 페이지로 이동합니다.');
-      navigate('/login');
+      navigate('/', { replace: true });
       return;
     }
 

--- a/src/chat/Chat.jsx
+++ b/src/chat/Chat.jsx
@@ -180,6 +180,26 @@ export default function Chat() {
     return `${year}년 ${month}월 ${day}일`;
   };
 
+  const formatMessageText = (text) => {
+    const maxLength = 18;
+    const lines = [];
+    let currentLine = '';
+
+    for (let i = 0; i < text.length; i++) {
+      currentLine += text[i];
+      if (currentLine.length === maxLength) {
+        lines.push(currentLine);
+        currentLine = '';
+      }
+    }
+
+    if (currentLine) {
+      lines.push(currentLine);
+    }
+
+    return lines.join('\n');
+  };
+
   const handleSendMessage = (e) => {
     e.preventDefault();
     const text = e.target.message.value.trim();
@@ -232,7 +252,7 @@ export default function Chat() {
                 msg.sender === '나' ? styles['my-message'] : styles['other-message']
               }`}
             >
-              <p>{msg.text}</p>
+              <p style={{ whiteSpace: 'pre-wrap' }}>{formatMessageText(msg.text)}</p>
               <span className={styles['msg-time']}>{msg.time}</span>
             </div>
           ))}

--- a/src/chat/Chat.module.css
+++ b/src/chat/Chat.module.css
@@ -1,10 +1,16 @@
 .chat-page {
   display: flex;
+  flex-direction: row;
   background-color: #f8f8f8;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
 }
 
 .chat-window {
   width: 550px;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   padding-left: 35px;
@@ -15,6 +21,9 @@
   text-align: center;
   font-size: 0.9rem;
   color: #8e8e8e;
+  padding-top: 20px;
+  padding-bottom: 10px;
+  flex-shrink: 0;
 }
 
 .chat-text,
@@ -22,6 +31,7 @@
   text-align: center;
   color: #8e8e8e;
   margin-bottom: 1rem;
+  flex-shrink: 0;
 }
 
 .messages {
@@ -31,7 +41,7 @@
   gap: 10px;
   overflow-y: auto;
   overflow-x: hidden;
-  max-height: calc(100vh - 176px);
+  min-height: 0;
 }
 
 .messages::-webkit-scrollbar {
@@ -88,6 +98,8 @@
   margin-top: 10px;
   padding: 10px;
   position: relative;
+  flex-shrink: 0;
+  padding-bottom: 20px;
 }
 
 .message-input input,

--- a/src/chat/Chat.module.css
+++ b/src/chat/Chat.module.css
@@ -61,7 +61,9 @@
   font-size: 0.95rem;
   margin: 0;
   word-wrap: break-word;
+  word-break: break-all;
   white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 .message span {

--- a/src/chat/Chat.module.css
+++ b/src/chat/Chat.module.css
@@ -51,6 +51,7 @@
   font-size: 0.95rem;
   margin: 0;
   word-wrap: break-word;
+  white-space: pre-wrap;
 }
 
 .message span {
@@ -89,17 +90,34 @@
   position: relative;
 }
 
-.message-input input {
+.message-input input,
+.message-input textarea {
   flex: 1;
   padding: 14px 70px 14px 20px;
   border-radius: 25px;
   font-size: 0.95rem;
   outline: none;
   border: none;
+  font-family: 'pretendard', sans-serif;
+  line-height: 1.4;
+  overflow-y: auto;
+  word-wrap: break-word;
+  word-break: break-all;
+  white-space: pre-wrap;
 }
 
-.message-input input:focus {
+.message-input input:focus,
+.message-input textarea:focus {
   border-color: #ff6b9f;
+}
+
+.message-input textarea::-webkit-scrollbar {
+  width: 6px;
+}
+
+.message-input textarea::-webkit-scrollbar-thumb {
+  background-color: #ccc;
+  border-radius: 3px;
 }
 
 .message-input button {

--- a/src/chat/ChatList.jsx
+++ b/src/chat/ChatList.jsx
@@ -8,7 +8,16 @@ import Arrow from "../assets/arrow";
 
 export default function Main() {
   const navigate = useNavigate();
-  const { rooms, setRooms, setCurrentRoom } = useChatStore();
+  const { rooms, setRooms, currentRoom, setCurrentRoom } = useChatStore();
+
+  const getLastReadTime = (roomId) => {
+    try {
+      const lastReadTimes = JSON.parse(localStorage.getItem('chat_last_read') || '{}');
+      return lastReadTimes[roomId] || 0;
+    } catch {
+      return 0;
+    }
+  };
 
   useEffect(() => {
     const loadChatRooms = async () => {
@@ -30,6 +39,17 @@ export default function Main() {
         const mappedRooms = Object.values(uniqueChats)
           .sort((a, b) => new Date(b.lastActiveAt) - new Date(a.lastActiveAt))
           .map((chat) => {
+            const lastReadTime = getLastReadTime(chat.roomId);
+            const lastActiveTime = new Date(chat.lastActiveAt).getTime();
+
+            let lastSentTime = 0;
+            try {
+              const sentTimes = JSON.parse(localStorage.getItem('chat_last_sent') || '{}');
+              lastSentTime = sentTimes[chat.roomId] || 0;
+            } catch {}
+
+            const hasUnread = lastActiveTime > lastReadTime && lastActiveTime > lastSentTime;
+
             return {
               roomId: chat.roomId,
               opponentId: chat.opponentLoginId,
@@ -41,7 +61,7 @@ export default function Main() {
               age: null,
               address: null,
               gender: null,
-              unread: false,
+              unread: hasUnread,
             };
           });
 
@@ -54,9 +74,19 @@ export default function Main() {
     };
 
     loadChatRooms();
+    const interval = setInterval(loadChatRooms, 3000);
+    return () => clearInterval(interval);
   }, [setRooms]);
 
   const handleChatClick = (room) => {
+    try {
+      const lastReadTimes = JSON.parse(localStorage.getItem('chat_last_read') || '{}');
+      lastReadTimes[room.roomId] = Date.now();
+      localStorage.setItem('chat_last_read', JSON.stringify(lastReadTimes));
+    } catch (error) {
+      console.error('읽음 처리 오류:', error);
+    }
+
     setCurrentRoom({
       roomId: room.roomId,
       opponentId: room.opponentId,
@@ -90,26 +120,29 @@ export default function Main() {
               </div>
             </div>
           ) : (
-            rooms.map((room) => (
-              <div
-                key={room.roomId}
-                className={styles["chat-item"]}
-                onClick={() => handleChatClick(room)}
-              >
-                <div className={styles["avatar"]}>
-                  <User />
-                </div>
-                <div className={styles["chat-info"]}>
-                  <div className={styles["chat-username"]}>
-                    {room.otherUserName || `유저 ${room.opponentId}`} <span>@{room.opponentId}</span>
+            rooms.map((room) => {
+              const isActive = currentRoom?.roomId === room.roomId;
+              return (
+                <div
+                  key={room.roomId}
+                  className={`${styles["chat-item"]} ${isActive ? styles["chat-item-active"] : ""}`}
+                  onClick={() => handleChatClick(room)}
+                >
+                  <div className={styles["avatar"]}>
+                    <User />
                   </div>
-                  <div className={styles["chat-message"]}>
-                    {room.lastMessage || "메시지를 보내보세요"}
+                  <div className={styles["chat-info"]}>
+                    <div className={styles["chat-username"]}>
+                      {room.otherUserName || `유저 ${room.opponentId}`} <span>@{room.opponentId}</span>
+                    </div>
+                    <div className={styles["chat-message"]}>
+                      {room.lastMessage || "메시지를 보내보세요"}
+                    </div>
                   </div>
+                  {room.unread && <div className={styles["unread-dot"]}></div>}
                 </div>
-                {room.unread && <div className={styles["unread-dot"]}></div>}
-              </div>
-            ))
+              );
+            })
           )}
         </div>
       </div>

--- a/src/chat/ChatList.jsx
+++ b/src/chat/ChatList.jsx
@@ -27,21 +27,23 @@ export default function Main() {
           }
         });
 
-        const mappedRooms = Object.values(uniqueChats).map((chat) => {
-          return {
-            roomId: chat.roomId,
-            opponentId: chat.opponentLoginId,
-            opponentUserId: chat.opponentUserId,
-            otherUserName: chat.opponentName || "알 수 없는 사용자",
-            lastMessage: chat.lastMessage || "메시지 없음",
-            lastActiveAt: chat.lastActiveAt,
-            tags: [],
-            age: null,
-            address: null,
-            gender: null,
-            unread: false,
-          };
-        });
+        const mappedRooms = Object.values(uniqueChats)
+          .sort((a, b) => new Date(b.lastActiveAt) - new Date(a.lastActiveAt))
+          .map((chat) => {
+            return {
+              roomId: chat.roomId,
+              opponentId: chat.opponentLoginId,
+              opponentUserId: chat.opponentUserId,
+              otherUserName: chat.opponentName || "알 수 없는 사용자",
+              lastMessage: chat.lastMessage || "메시지 없음",
+              lastActiveAt: chat.lastActiveAt,
+              tags: [],
+              age: null,
+              address: null,
+              gender: null,
+              unread: false,
+            };
+          });
 
         setRooms(mappedRooms);
       } catch (error) {
@@ -80,16 +82,12 @@ export default function Main() {
 
         <div className={styles["chat-list"]}>
           {rooms.length === 0 ? (
-            <div
-              style={{
-                padding: "40px 20px",
-                textAlign: "center",
-                color: "#999",
-              }}
-            >
-              아직 채팅방이 없습니다.
-              <br />
-              랜덤 매칭을 시작해보세요!
+            <div className={styles["empty-state"]}>
+              <div className={styles["empty-title"]}>
+                아직 채팅방이 없습니다.
+                <br />
+                랜덤 매칭을 시작해보세요!
+              </div>
             </div>
           ) : (
             rooms.map((room) => (
@@ -98,17 +96,12 @@ export default function Main() {
                 className={styles["chat-item"]}
                 onClick={() => handleChatClick(room)}
               >
-                <div className={styles["profile"]}>
-                  <div className={styles["avatar"]}>
-                    <User />
-                  </div>
+                <div className={styles["avatar"]}>
+                  <User />
                 </div>
                 <div className={styles["chat-info"]}>
                   <div className={styles["chat-username"]}>
-                    {room.otherUserName || `유저 ${room.opponentId}`}
-                    <span className={styles["chat-username-span"]}>
-                      @{room.opponentId}
-                    </span>
+                    {room.otherUserName || `유저 ${room.opponentId}`} <span>@{room.opponentId}</span>
                   </div>
                   <div className={styles["chat-message"]}>
                     {room.lastMessage || "메시지를 보내보세요"}

--- a/src/chat/ChatList.module.css
+++ b/src/chat/ChatList.module.css
@@ -105,6 +105,14 @@
   background-color: #f9fafb;
 }
 
+.chat-item-active {
+  background-color: #e8e8e8;
+}
+
+.chat-item-active:hover {
+  background-color: #e0e0e0;
+}
+
 .avatar {
   width: 40px;
   height: 40px;

--- a/src/chat/ChatList.module.css
+++ b/src/chat/ChatList.module.css
@@ -1,23 +1,27 @@
 .main-container {
-  background-color: #f8f9fa;
+  background-color: #f8f8f8;
+  height: 100vh;
   display: flex;
   align-items: center;
-  justify-content: left;
+  justify-content: flex-start;
   font-family: 'pretendard', sans-serif;
 }
 
 .chat-box {
-  width: 380px;
+  width: 370px;
   height: 720px;
   background: #fff;
   border-radius: 20px;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .chat-header {
   font-size: 15px;
   padding: 14px 18px;
   border-bottom: 1px solid #d6d6d7;
+  font-weight: 600;
 }
 
 .chat-header p {
@@ -32,8 +36,59 @@
 }
 
 .chat-list {
-  max-height: 720px;
+  flex: 1;
   overflow-y: auto;
+}
+
+.chat-list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.chat-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-list::-webkit-scrollbar-thumb {
+  background-color: #ccc;
+  border-radius: 4px;
+}
+
+.chat-list::-webkit-scrollbar-thumb:hover {
+  background-color: #999;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #8e8e8e;
+  font-size: 14px;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 606px;
+  color: #8e8e8e;
+  gap: 16px;
+}
+
+.empty-icon {
+  width: 100px;
+  height: 91px;
+  margin-bottom: 8px;
+}
+
+.empty-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #383b43;
+  text-align: center;
+  line-height: 1.5;
 }
 
 .chat-item {
@@ -43,6 +98,7 @@
   padding: 12px 16px;
   cursor: pointer;
   border-bottom: 1px solid #d6d6d7;
+  transition: background-color 0.2s;
 }
 
 .chat-item:hover {
@@ -55,12 +111,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 .chat-info {
   flex: 1;
   margin-left: 10px;
   line-height: 1.3;
+  min-width: 0;
 }
 
 .chat-username {
@@ -70,10 +128,10 @@
 }
 
 .chat-username span {
-  color: #5c5c5c;
-  font-weight: 600;
-  font-size: 16px;
-  margin-left: 2px;
+  color: #8e8e8e;
+  font-weight: 400;
+  font-size: 13px;
+  margin-left: 6px;
 }
 
 .chat-message {
@@ -91,4 +149,6 @@
   height: 8px;
   background-color: #3b82f6;
   border-radius: 50%;
+  flex-shrink: 0;
+  margin-left: 8px;
 }

--- a/src/chat/ChatUser.jsx
+++ b/src/chat/ChatUser.jsx
@@ -111,22 +111,22 @@ export default function User() {
   };
 
   const handleConfirmExit = async () => {
+    setShowExitModal(false);
+
     if (currentRoom?.roomId) {
       try {
         await deleteRoom(currentRoom.roomId);
         websocketService.leaveRoom(currentRoom.roomId);
         removeRoom(currentRoom.roomId);
-        leaveRoom();
       } catch (error) {
         console.error('채팅방 삭제 실패:', error);
         websocketService.leaveRoom(currentRoom.roomId);
         removeRoom(currentRoom.roomId);
-        leaveRoom();
       }
     }
 
-    setShowExitModal(false);
-    navigate('/main');
+    leaveRoom();
+    navigate('/main', { replace: true });
   };
 
   const PER_ROW = 3;

--- a/src/component/List.jsx
+++ b/src/component/List.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getAccessToken } from '../utils/cookies';
+import useChatStore from '../store/useChatStore';
 import axios from 'axios';
 import styles from './List.module.css';
 import User from '../assets/user';
@@ -10,6 +11,7 @@ const API_BASE_URL = 'http://gsmsv-1.yujun.kr:27919';
 
 export default function Main() {
   const navigate = useNavigate();
+  const { setCurrentRoom } = useChatStore();
   const [chatList, setChatList] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -51,7 +53,9 @@ export default function Main() {
       const mappedData = Object.values(uniqueChats)
         .sort((a, b) => new Date(b.lastActiveAt) - new Date(a.lastActiveAt))
         .map((chat) => ({
-          id: chat.roomId,
+          roomId: chat.roomId,
+          opponentId: chat.opponentLoginId,
+          opponentUserId: chat.opponentUserId,
           username: chat.opponentName || '알 수 없는 사용자',
           userId: `@${chat.opponentLoginId}` || '@unknown',
           lastMessage: chat.lastMessage || '메시지 없음',
@@ -67,8 +71,18 @@ export default function Main() {
     }
   };
 
-  const handleChatClick = (id) => {
-    navigate('/chat', { state: { chatId: id } });
+  const handleChatClick = (chat) => {
+    setCurrentRoom({
+      roomId: chat.roomId,
+      opponentId: chat.opponentId,
+      opponentUserId: chat.opponentUserId,
+      otherUserName: chat.username,
+      tags: [],
+      age: null,
+      address: null,
+      gender: null,
+    });
+    navigate('/chat');
   };
 
   return (
@@ -92,9 +106,9 @@ export default function Main() {
             ) : (
               chatList.map((chat) => (
                 <div
-                  key={chat.id}
+                  key={chat.roomId}
                   className={styles['chat-item']}
-                  onClick={() => handleChatClick(chat.id)}
+                  onClick={() => handleChatClick(chat)}
                 >
                   <div className={styles.avatar}>
                     <User />

--- a/src/component/List.module.css
+++ b/src/component/List.module.css
@@ -94,6 +94,14 @@
   background-color: #f9fafb;
 }
 
+.chat-item-active {
+  background-color: #e8e8e8;
+}
+
+.chat-item-active:hover {
+  background-color: #e0e0e0;
+}
+
 .avatar {
   width: 40px;
   height: 40px;
@@ -136,8 +144,24 @@
 .unread-dot {
   width: 8px;
   height: 8px;
-  background-color: #3b82f6;
+  background-color: #ff6b9f;
   border-radius: 50%;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+.unread-badge {
+  min-width: 20px;
+  height: 20px;
+  background-color: #ff6b9f;
+  color: white;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 0 6px;
   flex-shrink: 0;
   margin-left: 8px;
 }

--- a/src/component/User.jsx
+++ b/src/component/User.jsx
@@ -144,52 +144,48 @@ export default function User() {
   const tags1 = (user.tags || []).slice(0, PER_ROW);
   const tags2 = (user.tags || []).slice(PER_ROW, PER_ROW * 2);
 
-  if (loading) {
-    return (
-      <div className="user-container">
-        <div>로딩 중</div>
-      </div>
-    );
-  }
-
   return (
     <div className={styles["user-container"]}>
       <aside className={styles["user-card"]}>
-        <div className={styles["user-wrap"]}>
-          <img src={profileImg} alt="아이콘" className={styles.icon} />
-        </div>
-
-        <div className={styles["user-body"]}>
-          <div className={styles["user-name"]}>{user.name}</div>
-          <div className={styles["user-id"]}>{user.handle}</div>
-
-          <div className={styles["user-tag-card"]}>
-            <div className={`${styles["user-tags"]} ${styles["user-tags1"]}`}>
-              {tags1.map((t, i) => (
-                <span key={`t1-${i}`} className={styles["user-tag"]}>
-                  {t}
-                </span>
-              ))}
+        {!loading && (
+          <>
+            <div className={styles["user-wrap"]}>
+              <img src={profileImg} alt="아이콘" className={styles.icon} />
             </div>
-            {tags2.length > 0 && (
-              <div className={`${styles["user-tags"]} ${styles["user-tags2"]}`}>
-                {tags2.map((t, i) => (
-                  <span key={`t2-${i}`} className={styles["user-tag"]}>
-                    {t}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
 
-          <button
-            type="button"
-            className={styles["user-button"]}
-            onClick={() => navigate("/profile")}
-          >
-            프로필
-          </button>
-        </div>
+            <div className={styles["user-body"]}>
+              <div className={styles["user-name"]}>{user.name}</div>
+              <div className={styles["user-id"]}>{user.handle}</div>
+
+              <div className={styles["user-tag-card"]}>
+                <div className={`${styles["user-tags"]} ${styles["user-tags1"]}`}>
+                  {tags1.map((t, i) => (
+                    <span key={`t1-${i}`} className={styles["user-tag"]}>
+                      {t}
+                    </span>
+                  ))}
+                </div>
+                {tags2.length > 0 && (
+                  <div className={`${styles["user-tags"]} ${styles["user-tags2"]}`}>
+                    {tags2.map((t, i) => (
+                      <span key={`t2-${i}`} className={styles["user-tag"]}>
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <button
+                type="button"
+                className={styles["user-button"]}
+                onClick={() => navigate("/profile")}
+              >
+                프로필
+              </button>
+            </div>
+          </>
+        )}
       </aside>
     </div>
   );

--- a/src/component/User.jsx
+++ b/src/component/User.jsx
@@ -185,7 +185,7 @@ export default function User() {
           <button
             type="button"
             className={styles["user-button"]}
-            onClick={() => navigate("/Profile")}
+            onClick={() => navigate("/profile")}
           >
             프로필
           </button>

--- a/src/main/Main.jsx
+++ b/src/main/Main.jsx
@@ -1,9 +1,21 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getAccessToken } from '../utils/cookies';
 import List from '../component/List';
 import Random from '../component/Random';
 import User from '../component/User';
 import './index.css';
 
 export default function Main() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = getAccessToken();
+    if (!token) {
+      navigate('/', { replace: true });
+    }
+  }, [navigate]);
+
   return (
     <div className="main-page">
       <div className="chat-list-section">

--- a/src/profile/Profile.css
+++ b/src/profile/Profile.css
@@ -144,6 +144,7 @@ body {
   cursor: pointer;
   outline: none;
   border: none;
+  padding: 0;
 }
 
 .p-edit:focus,

--- a/src/profile/Profile.css
+++ b/src/profile/Profile.css
@@ -153,40 +153,42 @@ body {
 }
 
 /* 카테고리 섹션 */
-/* .p-category-section {
+.p-category-section {
   margin: 15px 10px 10px 12px;
-  width: 310px;
-} */
+}
 
 .p-category-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-top: 20px;
+  justify-content: center;
 }
 
-.p-category-btn {
-  background: #ffffff;
-  border: 1px solid #d6d6d7;
-  border-radius: 20px;
-  padding: 8px 12px;
-  font-size: 12px;
-  font-weight: 500;
-  color: #858486;
+.p-category-item {
+  background-color: #ffffff;
+  color: #5c5c5c;
+  padding: 10px 16px;
+  border-radius: 100px;
+  font-size: 13px;
   cursor: pointer;
-  transition: all 0.3s;
+  transition: all 0.2s;
+  border: 1px solid #d6d6d7;
+  box-sizing: border-box;
+  text-align: center;
   white-space: nowrap;
 }
 
-.p-category-btn:hover {
-  background: #ff99b8;
+.p-category-item:hover {
+  background-color: #d6d6d7;
 }
 
-.p-category-btn.active {
-  background: #ff6b9f;
+.p-category-item.active {
+  background-color: #ff6b9f;
+  color: white;
   border-color: #ff6b9f;
-  color: #ffffff;
 }
 
 .p-category-apply {

--- a/src/profile/Profile.jsx
+++ b/src/profile/Profile.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import "./Profile.css";
 import HIcon from "../assets/profile-h.svg";
 import { getMyProfile, updateMyProfile } from "../api/profile";
+import { getAccessToken } from "../utils/cookies";
 
 const Profile = () => {
   const [profile, setProfile] = useState({
@@ -22,6 +23,14 @@ const Profile = () => {
 
   const navigate = useNavigate();
   const goHome = () => navigate("/main");
+
+  // 토큰 검증
+  useEffect(() => {
+    const token = getAccessToken();
+    if (!token) {
+      navigate('/', { replace: true });
+    }
+  }, [navigate]);
 
   useEffect(() => {
     const script = document.createElement('script');

--- a/src/profile/Profile.jsx
+++ b/src/profile/Profile.jsx
@@ -359,9 +359,9 @@ const Profile = () => {
         <>
           <div className="p-category-grid">
             {categoryOptions.map((category) => (
-              <button
+              <div
                 key={category}
-                className={`p-category-btn ${
+                className={`p-category-item ${
                   (Array.isArray(tempValue) ? tempValue : []).includes(category)
                     ? "active"
                     : ""
@@ -369,10 +369,10 @@ const Profile = () => {
                 onClick={() => handleCategoryClick(category)}
               >
                 {category}
-              </button>
+              </div>
             ))}
           </div>
-          <div style={{ marginTop: "10px", display: "flex", gap: "10px" }}>
+          <div style={{ marginTop: "20px", display: "flex", gap: "10px", justifyContent: "center" }}>
             <button
               className="p-cancel"
               onClick={(e) => {
@@ -408,14 +408,13 @@ const Profile = () => {
           <div className="p-category-grid" style={{ marginTop: "10px" }}>
             {profile.categories && profile.categories.length > 0 ? (
               profile.categories.map((category) => (
-                <button
+                <div
                   key={category}
-                  className="p-category-btn active"
-                  disabled
+                  className="p-category-item active"
                   style={{ cursor: "default" }}
                 >
                   {category}
-                </button>
+                </div>
               ))
             ) : (
               <span className="p-no-category" style={{ color: "#888" }}>

--- a/src/profile/Profile.jsx
+++ b/src/profile/Profile.jsx
@@ -23,6 +23,17 @@ const Profile = () => {
   const navigate = useNavigate();
   const goHome = () => navigate("/main");
 
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+    script.async = true;
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
   // 카테고리 옵션들
   const categoryOptions = [
     "운동",
@@ -63,6 +74,20 @@ const Profile = () => {
   const categoryReverseMap = Object.fromEntries(
     Object.entries(categoryMap).map(([ko, en]) => [en, ko])
   );
+
+  // 다음 주소 API 실행 함수
+  const execDaumPostcode = () => {
+    if (window.daum && window.daum.Postcode) {
+      new window.daum.Postcode({
+        oncomplete: (data) => {
+          const fullAddress = `${data.sido} ${data.sigungu} ${data.bname}`;
+          setTempValue(fullAddress);
+        },
+      }).open();
+    } else {
+      alert('주소 검색 기능을 불러오는 중입니다. 잠시 후 다시 시도해주세요.');
+    }
+  };
 
   // 프로필 조회
   useEffect(() => {
@@ -123,6 +148,13 @@ const Profile = () => {
       setTempValue(categoriesCopy);
     } else if (field === "age") {
       setTempValue(profile.age.toString());
+    } else if (field === "location") {
+      // 주소 필드인 경우 현재 주소를 tempValue에 설정하고 바로 다음 주소 API 실행
+      setTempValue(profile[field] || "");
+      // setTimeout을 사용하여 상태 업데이트 후 API 실행
+      setTimeout(() => {
+        execDaumPostcode();
+      }, 0);
     } else {
       setTempValue(profile[field] || "");
     }
@@ -285,6 +317,7 @@ const Profile = () => {
               }
             }}
             autoFocus
+            readOnly={fieldKey === "location"}
           />
           <button
             className="p-apply"

--- a/src/services/chatApi.js
+++ b/src/services/chatApi.js
@@ -33,9 +33,8 @@ chatApi.interceptors.response.use(
     if (error.response?.status === 401) {
       clearTokens();
 
-      if (window.location.pathname !== '/login') {
-        alert('로그인이 필요합니다. 로그인 페이지로 이동합니다.');
-        window.location.href = '/login';
+      if (window.location.pathname !== '/' && window.location.pathname !== '/login') {
+        window.location.href = '/';
       }
     }
     return Promise.reject(error);

--- a/src/store/useChatStore.js
+++ b/src/store/useChatStore.js
@@ -69,6 +69,7 @@ const useChatStore = create(
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         roomMessages: state.roomMessages,
+        currentRoom: state.currentRoom,
       }),
     }
   )


### PR DESCRIPTION
## 개요
채팅 UI/UX 개선 및 안읽음 메시지 추적 기능 구현

## 주요 변경사항

### 1. 로딩 상태 개선
- 메인 페이지 및 사용자 프로필 컴포넌트에서 새로고침 시 "로딩중..." 텍스트 대신 빈 화면 표시
- `loading` 초기값을 `false`로 변경하여 데이터 없을때 깔끔한 UI 제공

### 2. 채팅방 메시지 분리 및 스크롤 최적화
- **문제점**: 채팅방 전환 시 이전 대화 내용이 새 채팅방에 일시적으로 표시되는 버그
- **해결 방법**: 
  - `useEffect` 의존성 배열에서 `messages` 제거
  - 채팅방 전환 시 `setMessages([])`로 즉시 초기화
  - Race condition 방지: 비동기 채팅 기록 로드 시 roomId 검증 추가

### 3. 안읽음 메시지 표시 (로컬스토리지기반)
- **구현 내용**:
  - `chat_last_read`: 각 채팅방의 마지막 읽은 시간 저장
  - `chat_last_sent`: 각 채팅방의 마지막 메시지 전송 시간 저장
  - 안읽음 조건: `lastActiveTime > lastReadTime && lastActiveTime > lastSentTime`
  
- **적용 위치**:
  - 메인 페이지 채팅 목록 (`List.jsx`)
  - 채팅 페이지 사이드바 (`ChatList.jsx`)
  - 실시간 업데이트: 메시지 수신/채팅방 진입 시 자동 읽음 처리

- **UI 표시**: 분홍색 작은 원 표시

### 4. 현재 대화 중인 채팅방 강조
- 채팅 페이지에서 현재 선택된 채팅방을 어두운 회색 배경으로 표시
- `currentRoom.roomId` 비교하여 활성 상태 판별
- 메인 페이지에서는 활성 표시 없음 (채팅 페이지 전용)

### 5. 새로고침 시 상태 유지
- `useChatStore`의 `partialize` 설정에 `currentRoom` 추가
- 채팅 중 새로고침해도 현재 대화 상대 정보 유지 (이름이 "unknown"으로 바뀌는 버그 해결)